### PR TITLE
Require Symfony 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "symfony/symfony": ">=2.1"
+        "symfony/symfony": ">=2.2"
     },
     "suggest":  {
         "twitter/bootstrap": "2.3.*",


### PR DESCRIPTION
The class `Symfony\Component\PropertyAccess\PropertyAccess` was not supported until 2.2.  The form types will not function properly on symfony 2.1.  

PR changes composer to require >=2.2.
