### PR TITLE
Fix for multiple option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+/.idea

--- a/DependencyInjection/LifoTypeaheadExtension.php
+++ b/DependencyInjection/LifoTypeaheadExtension.php
@@ -82,7 +82,7 @@ class LifoTypeaheadExtension extends Extension implements PrependExtensionInterf
     protected function configureTwigBundle(ContainerBuilder $container, array $config)
     {
         if ($container->hasExtension('twig')) {
-            $resources = array('LifoTypeaheadBundle:Form:typeahead.html.twig');
+            $resources = array('@LifoTypeahead\Form\typeahead.html.twig');
             if (Kernel::VERSION_ID >= '20600') {
                 $container->prependExtensionConfig('twig', array('form_themes' => $resources));
             } else {

--- a/DependencyInjection/LifoTypeaheadExtension.php
+++ b/DependencyInjection/LifoTypeaheadExtension.php
@@ -82,7 +82,7 @@ class LifoTypeaheadExtension extends Extension implements PrependExtensionInterf
     protected function configureTwigBundle(ContainerBuilder $container, array $config)
     {
         if ($container->hasExtension('twig')) {
-            $resources = array('LifoTypeaheadBundle:Form:typeahead.html.twig');
+            $resources = array('@LifoTypeaheadBundle\Form\typeahead.html.twig');
             if (Kernel::VERSION_ID >= '20600') {
                 $container->prependExtensionConfig('twig', array('form_themes' => $resources));
             } else {

--- a/DependencyInjection/LifoTypeaheadExtension.php
+++ b/DependencyInjection/LifoTypeaheadExtension.php
@@ -82,7 +82,7 @@ class LifoTypeaheadExtension extends Extension implements PrependExtensionInterf
     protected function configureTwigBundle(ContainerBuilder $container, array $config)
     {
         if ($container->hasExtension('twig')) {
-            $resources = array('@LifoTypeaheadBundle\Form\typeahead.html.twig');
+            $resources = array('LifoTypeaheadBundle:Form:typeahead.html.twig');
             if (Kernel::VERSION_ID >= '20600') {
                 $container->prependExtensionConfig('twig', array('form_themes' => $resources));
             } else {

--- a/Resources/views/Form/typeahead.html.twig
+++ b/Resources/views/Form/typeahead.html.twig
@@ -1,6 +1,6 @@
 {% block entity_typeahead_widget %}
 {% spaceless %}
-    {% set required, main_full_name, main_id, main_value, main_attr = false, full_name, id, value, attr %}
+    {% set main_full_name, main_id, main_value, main_attr = full_name, id, value, attr %}
 
     {# create visible autocomplete input #}
     {% set id = main_id ~ '_text' %}

--- a/Resources/views/Form/typeahead.html.twig
+++ b/Resources/views/Form/typeahead.html.twig
@@ -56,7 +56,11 @@
 
 {% block entity_typeahead_list_widget %}
 {% spaceless %}
-    {% set _id, _value, _render = child, child, child %}
+    {% if simple or child == null %}
+        {% set _id, _value, _render = child, child, child %}
+    {% else %}
+        {% set _id, _value, _render = child.id, attribute(child, property ?: 'id'), attribute(child, render) %}
+    {% endif %}
     <li{% if child is not null %} data-value="{{ _id }}"{% endif %}>
         <input{% if child is not null %} id="{{ id ~ '_' ~ _id }}" name="{{ full_name }}[]" value="{{ _value }}"{% endif %} type="hidden" />
         <a href="" class="lifo-typeahead-item" title="{{ "Click to remove"|trans }}">{{ child is not null ? _render : '' }}</a>

--- a/Resources/views/Form/typeahead.html.twig
+++ b/Resources/views/Form/typeahead.html.twig
@@ -56,11 +56,7 @@
 
 {% block entity_typeahead_list_widget %}
 {% spaceless %}
-    {% if simple %}
-        {% set _id, _value, _render = child, child, child %}
-    {% else %}
-        {% set _id, _value, _render = child.id, attribute(child, property ?: 'id'), attribute(child, render) %}
-    {% endif %}
+    {% set _id, _value, _render = child, child, child %}
     <li{% if child is not null %} data-value="{{ _id }}"{% endif %}>
         <input{% if child is not null %} id="{{ id ~ '_' ~ _id }}" name="{{ full_name }}[]" value="{{ _value }}"{% endif %} type="hidden" />
         <a href="" class="lifo-typeahead-item" title="{{ "Click to remove"|trans }}">{{ child is not null ? _render : '' }}</a>

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
         }
     ],
     "require": {
-        "symfony/symfony": "^2.6 || ^3.0"
     },
     "suggest":  {
         "twbs/bootstrap": "Bootstrap framework",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "symfony/symfony": "^2.6 || ^3.0"
+        "symfony/symfony": "^2.5 || ^3.0"
     },
     "suggest":  {
         "twbs/bootstrap": "Bootstrap framework",

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,6 @@
             "email": "lifo2013@gmail.com"
         }
     ],
-    "require": {
-    },
     "suggest":  {
         "twbs/bootstrap": "Bootstrap framework",
         "mopa/bootstrap-bundle": "Bundle to automatically enable Bootstrap styles for Symfony"


### PR DESCRIPTION
When multiple child is set to null (line 30) and on line 62 is called child.id
That comprobation throws an error. I don't fully understand why it calls for child.id because after I quit this if() the field started working and it does everything that it should do (adds the <ul>, saves on the DB, list the existing ones if the Entity have them, etc.)
PS: Sorry about my bad english I'm a spanish speaker